### PR TITLE
Use 2^x for length of field name in link messages

### DIFF
--- a/esm/dataobjects.js
+++ b/esm/dataobjects.js
@@ -455,7 +455,7 @@ export class DataObjects {
       var [version, flags] = struct.unpack_from('<BB', this.fh, offset);
       offset += 2;
       assert(version == 1);
-      let size_of_length_of_link_name = Math.pow((flags & 0b00000011), 2);
+      let size_of_length_of_link_name = Math.pow(2, (flags & 0b00000011));
       let link_type_field_present = flags & 0b00000100;
       let link_name_character_set_field_present = flags & 0b00010000;
       var link_type;


### PR DESCRIPTION
Fixes #10 