### PR TITLE
make filter_info object keys consistent

### DIFF
--- a/esm/dataobjects.js
+++ b/esm/dataobjects.js
@@ -128,7 +128,8 @@ export class DataObjects {
         filter_info.set('name', name);
         let client_values = struct.unpack_from(`<${num_client_values}i`, buf, offset);
         offset += (4 * num_client_values);
-        filter_info.set('client_data_values', client_values);
+        filter_info.set('client_data', client_values);
+        filter_info.set('client_data_values', num_client_values);
         filters.push(filter_info);
       }
     }


### PR DESCRIPTION
Currently v1 filter pipelines return an object with the client data values as an array in the property `filter_info.client_data`, and the length of the array (which is read directly from the filter pipeline message) in `filter_info.client_data_values`.

The code that reads v2 filter pipelines instead puts the client data values in `filter_info.client_data_values`, and does not add the length of the client data array in the filter_info object.

This PR makes the filter_info object returned from  `get_filter_pipeline` consistent between v1 and v2 filter pipelines.